### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/Control & loop Statements/Whileloop.py
+++ b/Control & loop Statements/Whileloop.py
@@ -10,7 +10,7 @@ Python interprets any non-zero numbers as True. None and '0' are interpreted as 
 """
 #program to sum n digits
 n = int(input("Enter a number: "))
-#intializing sum and counter 
+#initializing sum and counter 
 sum = 0
 counter = 1
 

--- a/Django/ReadMe.md
+++ b/Django/ReadMe.md
@@ -87,7 +87,7 @@ you generate instructions to db , So once after generating
 instructions you should ask the db to follow instructions
 to make table so to do that run the following command. \
 ``python manage.py migrate`` \
-One thing we need to keep in mind that everytime you create 
+One thing we need to keep in mind that every time you create 
 a new model or modify the existing one you need to 
 generate and execute instructions to get modified in db.
 
@@ -97,7 +97,7 @@ in our project they are : \
 ![img_3.png](img_3.png)
 
 #### Managing Data
-So once after creating the data in the db atleast there 
+So once after creating the data in the db at least there 
 must be one admin who should have access to modify data 
 for that we can use the django provided built-in 
 admin panel which can only be accessed to website creator

--- a/Functions/Functions.py
+++ b/Functions/Functions.py
@@ -1,5 +1,5 @@
 """
-Function is a block or chunk of code which is used for fullfilling a particular task 
+Function is a block or chunk of code which is used for fulfilling a particular task 
 
 Functions are three types:
 Built-in functions

--- a/OOPS/Classes&Objects.py
+++ b/OOPS/Classes&Objects.py
@@ -58,7 +58,7 @@ Traceback (most recent call last):
 AttributeError: 'ComplexNumbers' object has no attribute 'imag'
 """
 
-#we can delete a entire mathod of class by refering to it
+#we can delete a entire method of class by referring to it
 #del ComplexNumbers.get_data
 #num1.get_data()
 """

--- a/OOPS/Inheritance.py
+++ b/OOPS/Inheritance.py
@@ -34,7 +34,7 @@ class Triangle(Polygon):
         a,b,c = self.sides
         s = (a + b + c) / 2
         area = (s*(s-a)*(s-b)*(s-c)) ** 0.5
-        print("The area of traingle is %0.2f" %area)
+        print("The area of triangle is %0.2f" %area)
 
 t = Triangle()
 t.inputSides()

--- a/OOPS/oops.py
+++ b/OOPS/oops.py
@@ -6,7 +6,7 @@ objects have two properties namely attributes and behaviour
 """
 #creating a parrot class with attributes 
 #attributes are two types class and instance attributes 
-#instance attributes are defined under speacial method called as __init__()
+#instance attributes are defined under a special method named __init__()
 #every class is like a blue print for objects and objects posses every property of class
 class Parrot:
 
@@ -130,8 +130,8 @@ woo = Parrot("Woo",15)
 print("Blu is a {}".format(blu.__class__.species))
 print("Woo is also a {}".format(woo.__class__.species))
 
-# acces the instance attributes
-#where as instance attribues are accessed by object name.attribute name
+# access the instance attributes
+#where as instance attributes are accessed by object name.attribute name
 print("{} is {} years old.".format(blu.name, blu.age))
 print("{} is {} years old.".format(woo.name, woo.age))
 

--- a/Projects/Calculator.py
+++ b/Projects/Calculator.py
@@ -49,7 +49,7 @@ while True :
     list = []
     print("Simple Number Calculator")
     print(" Enter 'a' for addition")
-    print(" Enter 's' for substraction")
+    print(" Enter 's' for subtraction")
     print(" Enter 'm' for multiplication")
     print(" Enter 'v' for average")
     print(" Enter 'q' for quit")

--- a/Python Introduction/input & output.py
+++ b/Python Introduction/input & output.py
@@ -6,7 +6,7 @@ j=int(y)
 print("The Sum:", i+j)
 
 #Or else even we can simplify the above program:
-x=int(input("Enter Fisrt number:"))
+x=int(input("Enter First number:"))
 y=int(input("Enter Second Number:"))
 print("The Sum:", i+j)
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 <p align="left">
 This repo is all about educational purpose. It contains everything that you need to know about python3 with some docs and code which is constantly updating with either 
-  some concepts or projects. There is no pre-requisite for refering this repo, any one can start learning this as concepts are documented from scratch.
+  some concepts or projects. There is no pre-requisite for referring this repo, any one can start learning this as concepts are documented from scratch.
 </p>
 
 ## To Get a Copy
 - You can directly download the zip file by using the following link :
 <a href="https://github.com/venkateshtantravahi/Python-0-to-hero-/archive/refs/heads/main.zip" target="_blank">Python.zip</a>
-- You can directly clone the repo using https or ssh or github cli thorugh thier prompts 
+- You can directly clone the repo using https or ssh or github cli through their prompts 
 ``` 
 command: git clone https://github.com/venkateshtantravahi/Python-0-to-hero-.git
 ```
@@ -34,7 +34,7 @@ Anaconda : https://docs.anaconda.com/anaconda/install/linux/
 ```
 
 ### Creating Environments
-Once the installations is done you can create seperate envs to work standalone with this repo, which means that's like a private space where you install packages specific 
+Once the installations is done you can create separate envs to work standalone with this repo, which means that's like a private space where you install packages specific 
 to this repo which doesn't effect the global packages, you can create env's in wo different ways 
 - Creating env using pipenv
   ```

--- a/Regular Expressions/regular_expressions.py
+++ b/Regular Expressions/regular_expressions.py
@@ -5,8 +5,8 @@ MetaCHaracters : [] . ^ $ * ? {} () \ |
 . -> any single character except '\n'
 ^ -> checks if string starts with certain pattern or character
 $ -> checks if strings ends with certain character
-* -> used for counting occurances of patterns
-+, ? -> matches one or more occurances towards the pattern left
+* -> used for counting occurrences of patterns
++, ? -> matches one or more occurrences towards the pattern left
 {x,y}, [x-y] -> its used for matching number of characters where x is lower limit and y is upper limit
 | -> it acts like a or operator
 () ->grouping in pattern 

--- a/Working with data_types/Numeric Types/Working_with_numbers.py
+++ b/Working with data_types/Numeric Types/Working_with_numbers.py
@@ -23,13 +23,13 @@ print('Returns not a number type', math.nan)
 2.copysign(x,y) " copies the sign of one variable to other
 3.fabs(x) " returns the absolute value given by user
 4.factorial(x) " which returns factorial of number(5! = 5*4*3*2*1)
-5.floor(x) "returing the smallest rounding integer
+5.floor(x) "returning the smallest rounding integer
 6.fsum(iterable_object) "which sums up the items in iterable object
 7.gcd(x,y) "greatest common divisor of two numbers
 8.isfinite(x) "checks whether the number is finite or not
 9.isinf(x) " chcks the numbers is infinite or not
 10.isnan(x) " returns if data is not a number
-11.remainder(x,y) "gives the remiander of division
+11.remainder(x,y) "gives the remainder of division
 """
 
 x = float(input('Input some float or decimal value: '))

--- a/Working with data_types/Sequence Types/lists.py
+++ b/Working with data_types/Sequence Types/lists.py
@@ -35,7 +35,7 @@ l = [12,13]
 m_list.append(l)
 print('\nm_list ', m_list)
 
-#extend is used for appending a list to ther
+#extend is used for appending to a list
 d_list.extend(s_list)
 
 print('List after extending ', d_list)

--- a/Working with data_types/Sequence Types/tuples.py
+++ b/Working with data_types/Sequence Types/tuples.py
@@ -4,14 +4,14 @@ empty_tuple = ()
 print("Empty Tuple Declaration",empty_tuple)
 
 str_tuple = ('entiretyn', 'python','programming')
-print("Homogenious data in tuple",str_tuple)
+print("Homogeneous data in tuple",str_tuple)
 
 print(type(str_tuple))
 
 h_tuple = (1, 23, 34, 'string', 'guido', True)
-print("Heterogenous data in tuple",h_tuple)
+print("Heterogeneous data in tuple",h_tuple)
 
-# Tuple Concatination
+# Tuple Concatenation
 print(str_tuple + h_tuple)
 
 # Nesting Tuples

--- a/Working with data_types/Strings/Strings.py
+++ b/Working with data_types/Strings/Strings.py
@@ -4,11 +4,11 @@ import encodings
 1. capitalize() ==> COnverts first character to capital letter
 2. casefold() ==> converts to case folded strings
 3. center() ==> pads string with spcified character
-4. count() ==> returns the occurances of substrings inside string
+4. count() ==> returns the occurrences of substrings inside string
 5. encode() ==> returns encoded string
 6. endswith() ==> checks if string ends with the specified suffix
 7. expandtabs() ==> replaces tab character with spaces
-8. find() ==> returns the index of first occurance of substring
+8. find() ==> returns the index of first occurrence of substring
 9. format() ==> formats the string with some nice output
 10. string_index() ==> returns the index of sub-string
 11. isalnum() ==> checks if all are alphanumeric characters
@@ -40,7 +40,7 @@ else:
 print('Centered String:', st.center(30, '*'))
 
 msg = 'python is popular programming language'
-print('No of times p occured in string was: ', msg.count('p'))
+print('No of times p occurred in string was: ', msg.count('p'))
 
 sf = 'Python programming is cool, isn"t it?'
 print('Count without start and end is: ', sf.count('i'))

--- a/operators & Namespace/Operators.py
+++ b/operators & Namespace/Operators.py
@@ -3,7 +3,7 @@
 """
 1. Arithmetic operators
 + -> addition
-- -> substraction
+- -> subtraction
 * -> multiplication
 / -> division
 // -> integer division
@@ -81,10 +81,10 @@ print('Bitwise and of j is: ' + str(j << 3))
 Assignment Operators
  = -> assignment
  += -> adding with assignment
- -= -> substracting with assignment
+ -= -> subtracting with assignment
  *= -> multiplication with assignment
  /= -> division with assignment
- // -> integer divsion with assignment
+ // -> integer division with assignment
  %= -> modulus with assignment
  **= ->exponent with assignment
  ^= -> bitwise xor with assignment


### PR DESCRIPTION
Related to #1.

[`codespell --ignore-words-list=ans,fo --skip="*.ipynb"`](https://pypi.org/project/codespell)